### PR TITLE
Node implementation

### DIFF
--- a/src/api/Compooler.API.Tests/__snapshots__/SchemaTests.SchemaChanged.graphql
+++ b/src/api/Compooler.API.Tests/__snapshots__/SchemaTests.SchemaChanged.graphql
@@ -2,8 +2,13 @@ schema {
   query: Query
 }
 
-type CommuteGroup {
-  id: Int!
+"The node interface is implemented by entities that have a global unique identifier."
+interface Node {
+  id: ID!
+}
+
+type CommuteGroup implements Node {
+  id: ID!
   maxPassengers: Int!
   route: Route!
   passengers: [CommuteGroupPassenger!]!
@@ -51,6 +56,10 @@ type PageInfo {
 }
 
 type Query {
+  "Fetches an object given its ID."
+  node("ID of the object." id: ID!): Node
+  "Lookup nodes by a list of IDs."
+  nodes("The list of node IDs." ids: [ID!]!): [Node]!
   commuteGroups("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String): CommuteGroupsConnection
   users("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String): UsersConnection
 }
@@ -60,8 +69,8 @@ type Route {
   finish: GeographicCoordinates!
 }
 
-type User {
-  id: Int!
+type User implements Node {
+  id: ID!
   firstName: String!
   lastName: String!
   commuteGroups: [CommuteGroup!]!

--- a/src/api/Compooler.API/Extensions/HotChocolateConventions.cs
+++ b/src/api/Compooler.API/Extensions/HotChocolateConventions.cs
@@ -7,9 +7,11 @@ public static class HotChocolateConventions
     public static IRequestExecutorBuilder AddCompoolerConventions(
         this IRequestExecutorBuilder builder
     ) =>
-        builder.ModifyPagingOptions(options =>
-        {
-            options.AllowBackwardPagination = false;
-            options.RequirePagingBoundaries = false;
-        });
+        builder
+            .ModifyPagingOptions(options =>
+            {
+                options.AllowBackwardPagination = false;
+                options.RequirePagingBoundaries = false;
+            })
+            .AddGlobalObjectIdentification();
 }

--- a/src/api/Compooler.API/Types/Objects/CommuteGroupNodeType.cs
+++ b/src/api/Compooler.API/Types/Objects/CommuteGroupNodeType.cs
@@ -27,5 +27,16 @@ public class CommuteGroupNodeType : ObjectType<CommuteGroup>
 
                 return await dataLoader.LoadAsync(commuteGroup.DriverId, ctx.RequestAborted);
             });
+
+        descriptor
+            .ImplementsNode()
+            .IdField(x => x.Id)
+            .ResolveNode(
+                async (ctx, id) =>
+                {
+                    var dataLoader = ctx.Services.GetRequiredService<CommuteGroupByIdDataLoader>();
+                    return await dataLoader.LoadAsync(id, ctx.RequestAborted);
+                }
+            );
     }
 }

--- a/src/api/Compooler.API/Types/Objects/UserNodeType.cs
+++ b/src/api/Compooler.API/Types/Objects/UserNodeType.cs
@@ -37,5 +37,16 @@ public class UserNodeType : ObjectType<User>
                     ctx.RequestAborted
                 );
             });
+
+        descriptor
+            .ImplementsNode()
+            .IdField(x => x.Id)
+            .ResolveNode(
+                async (ctx, id) =>
+                {
+                    var dataLoader = ctx.Services.GetRequiredService<UserByIdDataLoader>();
+                    return await dataLoader.LoadAsync(id, ctx.RequestAborted);
+                }
+            );
     }
 }


### PR DESCRIPTION
Globally identify entities/objects (a.k.a nodes) as per Relay's [Object Identification](https://relay.dev/docs/guides/graphql-server-specification/#object-identification)