### PR TITLE
Take TimeOfDeparture into account when querying

### DIFF
--- a/src/api/Compooler.API.Tests/__snapshots__/SchemaTests.SchemaChanged.graphql
+++ b/src/api/Compooler.API.Tests/__snapshots__/SchemaTests.SchemaChanged.graphql
@@ -28,6 +28,24 @@ type GeographicCoordinates {
   longitude: Float!
 }
 
+"A connection to a list of items."
+type HistoricalRidesConnection {
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  "A list of edges."
+  edges: [HistoricalRidesEdge!]
+  "A flattened list of the nodes."
+  nodes: [Ride!]
+}
+
+"An edge in a connection."
+type HistoricalRidesEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: Ride!
+}
+
 type InvalidLatitudeError implements Error {
   code: String!
   message: String!
@@ -172,11 +190,30 @@ type TimeOfDepartureIsNotInTheFutureError implements Error {
   message: String!
 }
 
+"A connection to a list of items."
+type UpcomingRidesConnection {
+  "Information to aid in pagination."
+  pageInfo: PageInfo!
+  "A list of edges."
+  edges: [UpcomingRidesEdge!]
+  "A flattened list of the nodes."
+  nodes: [Ride!]
+}
+
+"An edge in a connection."
+type UpcomingRidesEdge {
+  "A cursor for use in pagination."
+  cursor: String!
+  "The item at the end of the edge."
+  node: Ride!
+}
+
 type User implements Node @authorize {
   id: ID!
   firstName: String!
   lastName: String!
-  rides("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String): RidesConnection
+  upcomingRides("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String): UpcomingRidesConnection
+  historicalRides("Returns the first _n_ elements from the list." first: Int "Returns the elements in the list that come after the specified cursor." after: String): HistoricalRidesConnection
 }
 
 type UserAlreadyExistsError implements Error {

--- a/src/api/Compooler.API/Types/Queries/RideQueries.cs
+++ b/src/api/Compooler.API/Types/Queries/RideQueries.cs
@@ -1,5 +1,6 @@
 using Compooler.API.Extensions;
 using Compooler.API.Types.Queries.Inputs;
+using Compooler.Domain;
 using Compooler.Domain.Entities.RideEntity;
 using Compooler.Persistence;
 using Compooler.Persistence.Queries;
@@ -42,6 +43,8 @@ public class RideQueries : ObjectType
                 // TODO: Paging? Possible to implement with in memory caching of ride IDs, since we'll need to compute all of the scores anyway
 
                 var dbContext = ctx.Services.GetRequiredService<CompoolerDbContext>();
+                var dateTimeOffsetProvider =
+                    ctx.Services.GetRequiredService<IDateTimeOffsetProvider>();
                 var input = ctx.ArgumentValue<RideRelevanceInput>("input");
                 var userId = ctx.GetRequiredUserId();
 
@@ -68,7 +71,8 @@ public class RideQueries : ObjectType
                         startResult.Value.Longitude,
                         finishResult.Value.Latitude,
                         finishResult.Value.Longitude,
-                        userId
+                        userId,
+                        dateTimeOffsetProvider
                     )
                     .ToListAsync();
             });

--- a/src/api/Compooler.Persistence.Tests/DataLoaders/RideIdsByUserId.cs
+++ b/src/api/Compooler.Persistence.Tests/DataLoaders/RideIdsByUserId.cs
@@ -14,7 +14,7 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
     private readonly CompoolerDbContext _dbContext = new(fixture.DbContextOptions);
 
     private static readonly IDateTimeOffsetProvider DateTimeOffsetProvider =
-        new FixedDateTimeOffsetProvider { Now = DateTimeOffset.Now.AddHours(25).ToUniversalTime() };
+        new FixedDateTimeOffsetProvider { Now = DateTimeOffset.Now.ToUniversalTime() };
 
     public Task InitializeAsync() => Task.CompletedTask;
 

--- a/src/api/Compooler.Persistence.Tests/DataLoaders/RideIdsByUserId.cs
+++ b/src/api/Compooler.Persistence.Tests/DataLoaders/RideIdsByUserId.cs
@@ -14,7 +14,7 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
     private readonly CompoolerDbContext _dbContext = new(fixture.DbContextOptions);
 
     private static readonly IDateTimeOffsetProvider DateTimeOffsetProvider =
-        new FixedDateTimeOffsetProvider { Now = DateTimeOffset.Now.ToUniversalTime() };
+        new FixedDateTimeOffsetProvider { Now = DateTimeOffset.Now.AddHours(25).ToUniversalTime() };
 
     public Task InitializeAsync() => Task.CompletedTask;
 
@@ -39,7 +39,11 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
 
         var rides = Enumerable
             .Range(0, 3)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: user.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: user.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         _dbContext.Rides.AddRange(rides);
@@ -70,7 +74,11 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
 
         var rides = Enumerable
             .Range(0, 3)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: driver.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: driver.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         _dbContext.Rides.AddRange(rides);
@@ -103,12 +111,20 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
 
         var drivingRides = Enumerable
             .Range(0, 1)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: user1.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: user1.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         var passengerRides = Enumerable
             .Range(0, 2)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: user2.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: user2.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         var rides = drivingRides.Concat(passengerRides).ToList();
@@ -144,12 +160,20 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
 
         var user1DrivingRides = Enumerable
             .Range(0, 2)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: user1.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: user1.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         var user2DrivingRides = Enumerable
             .Range(0, 2)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: user2.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: user2.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         var rides = user1DrivingRides.Concat(user2DrivingRides).ToList();
@@ -206,7 +230,7 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
         var result = await RideDataLoaders.GetRideIdsByUserIdAsync(
             [user.Id],
             _dbContext,
-            DateTimeOffsetProvider,
+            dateTimeOffsetProvider,
             new PagingArguments(first: rides.Count + 1),
             cancellationToken: default
         );
@@ -227,12 +251,20 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
 
         var user1DrivingRides = Enumerable
             .Range(0, 2)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: user1.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: user1.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         var user2DrivingRides = Enumerable
             .Range(0, 3)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: user2.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: user2.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         var rides = user1DrivingRides.Concat(user2DrivingRides).ToList();
@@ -287,21 +319,21 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
             TestEntityFactory
                 .CreateRide(
                     driverId: user.Id,
-                    timeOfDeparture: queryDateTimeOffsetProvider.Now.AddDays(-1),
+                    timeOfDeparture: queryDateTimeOffsetProvider.Past,
                     dateTimeOffsetProvider: creationDateTimeOffsetProvider
                 )
                 .RequiredSuccess(),
             TestEntityFactory
                 .CreateRide(
                     driverId: user.Id,
-                    timeOfDeparture: queryDateTimeOffsetProvider.Now.AddDays(1),
+                    timeOfDeparture: queryDateTimeOffsetProvider.Future,
                     dateTimeOffsetProvider: creationDateTimeOffsetProvider
                 )
                 .RequiredSuccess(),
             TestEntityFactory
                 .CreateRide(
                     driverId: user.Id,
-                    timeOfDeparture: queryDateTimeOffsetProvider.Now.AddDays(1),
+                    timeOfDeparture: queryDateTimeOffsetProvider.Future,
                     dateTimeOffsetProvider: creationDateTimeOffsetProvider
                 )
                 .RequiredSuccess()
@@ -333,7 +365,11 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
 
         var rides = Enumerable
             .Range(0, 5)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: user.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: user.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         _dbContext.Rides.AddRange(rides);
@@ -377,7 +413,11 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
 
         var rides = Enumerable
             .Range(0, 10)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: user.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: user.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         _dbContext.Rides.AddRange(rides);
@@ -414,7 +454,11 @@ public class RideIdsByUserId(DatabaseFixture fixture) : IAsyncLifetime
 
         var rides = Enumerable
             .Range(0, 5)
-            .Select(_ => TestEntityFactory.CreateRide(driverId: user.Id).RequiredSuccess())
+            .Select(_ =>
+                TestEntityFactory
+                    .CreateRide(driverId: user.Id, dateTimeOffsetProvider: DateTimeOffsetProvider)
+                    .RequiredSuccess()
+            )
             .ToList();
 
         _dbContext.Rides.AddRange(rides);

--- a/src/api/Compooler.Persistence.Tests/Queries/RideRelevance.cs
+++ b/src/api/Compooler.Persistence.Tests/Queries/RideRelevance.cs
@@ -230,7 +230,7 @@ public class RideRelevance(DatabaseFixture fixture) : IAsyncLifetime
 
         var result = await _dbContext
             .Rides.AsNoTracking()
-            .Where(r => rideIds.Contains(r.Id)) // Isolates this test's data from other tests
+            .Where(r => rideIds.Contains(r.Id))
             .FilterAndOrderByRelevance(
                 startLatitude: start.Latitude,
                 startLongitude: start.Longitude,

--- a/src/api/Compooler.Persistence.Tests/Queries/RideRelevance.cs
+++ b/src/api/Compooler.Persistence.Tests/Queries/RideRelevance.cs
@@ -13,7 +13,7 @@ public class RideRelevance(DatabaseFixture fixture) : IAsyncLifetime
     private readonly CompoolerDbContext _dbContext = new(fixture.DbContextOptions);
 
     private static readonly IDateTimeOffsetProvider DateTimeOffsetProvider =
-        new FixedDateTimeOffsetProvider { Now = DateTimeOffset.Now.AddHours(25).ToUniversalTime() };
+        new FixedDateTimeOffsetProvider { Now = DateTimeOffset.Now.ToUniversalTime() };
 
     private static readonly (double Latitude, double Longitude) VilniusOzoParkas = (
         Latitude: 54.720017,

--- a/src/api/Compooler.Persistence/Queries/RideRelevanceQuery.cs
+++ b/src/api/Compooler.Persistence/Queries/RideRelevanceQuery.cs
@@ -1,3 +1,4 @@
+using Compooler.Domain;
 using Compooler.Domain.Entities.RideEntity;
 using Compooler.Persistence.Configurations;
 using Microsoft.EntityFrameworkCore;
@@ -13,7 +14,8 @@ public static class RideRelevanceQuery
         double startLongitude,
         double finishLatitude,
         double finishLongitude,
-        string userId
+        string userId,
+        IDateTimeOffsetProvider dateTimeOffsetProvider
     )
     {
         var startPoint = new Point(startLongitude, startLatitude);
@@ -22,8 +24,10 @@ public static class RideRelevanceQuery
         // Filter out irrelevant rides
         // TODO: Filter out rides where user is passenger?
         const int maxProximityMeters = 15000;
+        var currentTime = dateTimeOffsetProvider.Now.ToUniversalTime();
         var filteredQuery = queryable
             .Where(ride => ride.DriverId != userId)
+            .Where(ride => ride.TimeOfDeparture > currentTime)
             .Where(ride =>
                 EF.Property<Point>(ride.Route.Start, RideConfiguration.PointPropertyName)
                     .IsWithinDistance(startPoint, maxProximityMeters)

--- a/src/api/Compooler.Tests.Utilities/Fixtures/DatabaseFixture.cs
+++ b/src/api/Compooler.Tests.Utilities/Fixtures/DatabaseFixture.cs
@@ -23,6 +23,7 @@ public class DatabaseFixture : IAsyncLifetime
 
         _contextOptions = new DbContextOptionsBuilder()
             .UseCompoolerDatabase(_dbContainer.GetConnectionString())
+            .EnableSensitiveDataLogging()
             .LogTo(Console.WriteLine, LogLevel.Information)
             .Options;
 

--- a/src/api/Compooler.Tests.Utilities/TestEntityFactory.cs
+++ b/src/api/Compooler.Tests.Utilities/TestEntityFactory.cs
@@ -41,7 +41,9 @@ public static class TestEntityFactory
             route: Route.Create(start: startCoords, finish: finishCoords),
             driverId: driverId ?? TestEntityFactory.CreateUserId(),
             maxPassengers: maxPassengers,
-            timeOfDeparture: timeOfDeparture ?? DateTimeOffsetProvider.Future,
+            timeOfDeparture: timeOfDeparture
+                ?? dateTimeOffsetProvider?.Now.AddDays(1)
+                ?? DateTimeOffsetProvider.Future,
             dateTimeOffsetProvider: dateTimeOffsetProvider ?? DateTimeOffsetProvider
         );
     }


### PR DESCRIPTION
- Some refactoring on persistence tests regarding date time offset provider
- Rename `me { rides }` to `me { upcomingRides }` and add `me { historicalRides }`. Readjust data loader tests to test both variants